### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ccxt
 prettyprinter
 requests
+jsonschema==3.2
+bravado
 unicorn-binance-websocket-api
-


### PR DESCRIPTION
Bravado is missing and Bravado installs newer jsonschema which removed a feature that makes the code not work. That is why it is neccessary to first install an older version of jsonschema